### PR TITLE
Moore-Penrose Inverse for C++/Eigen, MATLAB, Python/NumPy, LaTeX

### DIFF
--- a/iheartla/la_grammar/matrix_ebnf.py
+++ b/iheartla/la_grammar/matrix_ebnf.py
@@ -116,6 +116,7 @@ operations_in_matrix
     | sqrt_in_matrix_operator
     | function_operator
     | builtin_operators
+    | pseudoinverse_in_matrix_operator
     ;
 
 power_in_matrix_operator::Power
@@ -144,6 +145,10 @@ kronecker_product_in_matrix_operator::KroneckerProduct
 
 trans_in_matrix_operator::Transpose
     = f:factor_in_matrix /ᵀ/
+    ;
+
+pseudoinverse_in_matrix_operator::PseudoInverse
+    = f:factor_in_matrix /⁺/
     ;
     
 sqrt_in_matrix_operator::Squareroot

--- a/iheartla/la_grammar/operators_ebnf.py
+++ b/iheartla/la_grammar/operators_ebnf.py
@@ -16,6 +16,7 @@ operations
     | sqrt_operator
     | function_operator
     | builtin_operators
+    | pseudoinverse_operator
     ;
 
 
@@ -124,6 +125,10 @@ kronecker_product_operator::KroneckerProduct
 
 trans_operator::Transpose
     = f:factor /ᵀ/
+    ;
+
+pseudoinverse_operator::PseudoInverse
+    = f:factor /⁺/
     ;
     
 sqrt_operator::Squareroot

--- a/iheartla/la_gui/la_ctrl.py
+++ b/iheartla/la_gui/la_ctrl.py
@@ -43,7 +43,7 @@ class LaTextControl(bc.BaseTextControl):
                              'heart': '❤️', 'iheartla': 'I❤️LA',
                              'le':'≤', 'ge':'≥', 'ne': '≠', 'notin':'∉', 'div':'÷', 'nplus': '±',
                              'linner': '⟨', 'rinner':'⟩', 'num1': '𝟙',
-                             'hat': '\u0302', 'bar': '\u0304'
+                             'hat': '\u0302', 'bar': '\u0304', 'dag': '†', '^+': '⁺', 's+': '⁺'
                              }
         self.StyleSetSpec(self.STC_STYLE_LA_DEFAULT, "fore:#A9B7C6,back:{}".format(bc.BACKGROUND_COLOR))
         self.StyleSetSpec(self.STC_STYLE_LA_KW, "fore:#94558D,bold,back:{}".format(bc.BACKGROUND_COLOR))

--- a/iheartla/la_local_parsers/default_parser.py
+++ b/iheartla/la_local_parsers/default_parser.py
@@ -532,6 +532,8 @@ class grammardefaultParser(Parser):
                 self._function_operator_()
             with self._option():
                 self._builtin_operators_()
+            with self._option():
+                self._pseudoinverse_operator_()
             self._error('no available options')
 
     @tatsumasu('Add')
@@ -1405,6 +1407,17 @@ class grammardefaultParser(Parser):
             []
         )
 
+    @tatsumasu('PseudoInverse')
+    @nomemo
+    def _pseudoinverse_operator_(self):  # noqa
+        self._factor_()
+        self.name_last_node('f')
+        self._pattern('⁺')
+        self.ast._define(
+            ['f'],
+            []
+        )
+
     @tatsumasu('Squareroot')
     def _sqrt_operator_(self):  # noqa
         self._pattern('√')
@@ -2133,6 +2146,8 @@ class grammardefaultParser(Parser):
                 self._function_operator_()
             with self._option():
                 self._builtin_operators_()
+            with self._option():
+                self._pseudoinverse_in_matrix_operator_()
             self._error('no available options')
 
     @tatsumasu('Power')
@@ -2230,6 +2245,17 @@ class grammardefaultParser(Parser):
         self._factor_in_matrix_()
         self.name_last_node('f')
         self._pattern('ᵀ')
+        self.ast._define(
+            ['f'],
+            []
+        )
+
+    @tatsumasu('PseudoInverse')
+    @nomemo
+    def _pseudoinverse_in_matrix_operator_(self):  # noqa
+        self._factor_in_matrix_()
+        self.name_last_node('f')
+        self._pattern('⁺')
         self.ast._define(
             ['f'],
             []
@@ -5487,6 +5513,9 @@ class grammardefaultSemantics(object):
     def trans_operator(self, ast):  # noqa
         return ast
 
+    def pseudoinverse_operator(self, ast):  # noqa
+        return ast
+
     def sqrt_operator(self, ast):  # noqa
         return ast
 
@@ -5575,6 +5604,9 @@ class grammardefaultSemantics(object):
         return ast
 
     def trans_in_matrix_operator(self, ast):  # noqa
+        return ast
+
+    def pseudoinverse_in_matrix_operator(self, ast):  # noqa
         return ast
 
     def sqrt_in_matrix_operator(self, ast):  # noqa
@@ -6086,6 +6118,10 @@ class KroneckerProduct(ModelBase):
 
 
 class Transpose(ModelBase):
+    f = None
+
+
+class PseudoInverse(ModelBase):
     f = None
 
 

--- a/iheartla/la_local_parsers/init_parser.py
+++ b/iheartla/la_local_parsers/init_parser.py
@@ -528,6 +528,8 @@ class grammarinitParser(Parser):
                 self._function_operator_()
             with self._option():
                 self._builtin_operators_()
+            with self._option():
+                self._pseudoinverse_operator_()
             self._error('no available options')
 
     @tatsumasu('Add')
@@ -1401,6 +1403,17 @@ class grammarinitParser(Parser):
             []
         )
 
+    @tatsumasu('PseudoInverse')
+    @nomemo
+    def _pseudoinverse_operator_(self):  # noqa
+        self._factor_()
+        self.name_last_node('f')
+        self._pattern('⁺')
+        self.ast._define(
+            ['f'],
+            []
+        )
+
     @tatsumasu('Squareroot')
     def _sqrt_operator_(self):  # noqa
         self._pattern('√')
@@ -2129,6 +2142,8 @@ class grammarinitParser(Parser):
                 self._function_operator_()
             with self._option():
                 self._builtin_operators_()
+            with self._option():
+                self._pseudoinverse_in_matrix_operator_()
             self._error('no available options')
 
     @tatsumasu('Power')
@@ -2226,6 +2241,17 @@ class grammarinitParser(Parser):
         self._factor_in_matrix_()
         self.name_last_node('f')
         self._pattern('ᵀ')
+        self.ast._define(
+            ['f'],
+            []
+        )
+
+    @tatsumasu('PseudoInverse')
+    @nomemo
+    def _pseudoinverse_in_matrix_operator_(self):  # noqa
+        self._factor_in_matrix_()
+        self.name_last_node('f')
+        self._pattern('⁺')
         self.ast._define(
             ['f'],
             []
@@ -5411,6 +5437,9 @@ class grammarinitSemantics(object):
     def trans_operator(self, ast):  # noqa
         return ast
 
+    def pseudoinverse_operator(self, ast):  # noqa
+        return ast
+
     def sqrt_operator(self, ast):  # noqa
         return ast
 
@@ -5499,6 +5528,9 @@ class grammarinitSemantics(object):
         return ast
 
     def trans_in_matrix_operator(self, ast):  # noqa
+        return ast
+
+    def pseudoinverse_in_matrix_operator(self, ast):  # noqa
         return ast
 
     def sqrt_in_matrix_operator(self, ast):  # noqa
@@ -6010,6 +6042,10 @@ class KroneckerProduct(ModelBase):
 
 
 class Transpose(ModelBase):
+    f = None
+
+
+class PseudoInverse(ModelBase):
     f = None
 
 

--- a/iheartla/la_local_parsers/parser_c21f969b5f03d33d43e04f8f136e7682_2022-08-17-15-06-43.py
+++ b/iheartla/la_local_parsers/parser_c21f969b5f03d33d43e04f8f136e7682_2022-08-17-15-06-43.py
@@ -25,7 +25,7 @@ from tatsu.util import re, generic_main  # noqa
 KEYWORDS = {}  # type: ignore
 
 
-class grammare37f0136aa3ffaf149b351f6a4c948e9Buffer(Buffer):
+class grammarc21f969b5f03d33d43e04f8f136e7682Buffer(Buffer):
     def __init__(
         self,
         text,
@@ -37,7 +37,7 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Buffer(Buffer):
         namechars='',
         **kwargs
     ):
-        super(grammare37f0136aa3ffaf149b351f6a4c948e9Buffer, self).__init__(
+        super(grammarc21f969b5f03d33d43e04f8f136e7682Buffer, self).__init__(
             text,
             whitespace=whitespace,
             nameguard=nameguard,
@@ -49,7 +49,7 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Buffer(Buffer):
         )
 
 
-class grammare37f0136aa3ffaf149b351f6a4c948e9Parser(Parser):
+class grammarc21f969b5f03d33d43e04f8f136e7682Parser(Parser):
     def __init__(
         self,
         whitespace=re.compile('(?!.*)'),
@@ -61,12 +61,12 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Parser(Parser):
         parseinfo=True,
         keywords=None,
         namechars='',
-        buffer_class=grammare37f0136aa3ffaf149b351f6a4c948e9Buffer,
+        buffer_class=grammarc21f969b5f03d33d43e04f8f136e7682Buffer,
         **kwargs
     ):
         if keywords is None:
             keywords = KEYWORDS
-        super(grammare37f0136aa3ffaf149b351f6a4c948e9Parser, self).__init__(
+        super(grammarc21f969b5f03d33d43e04f8f136e7682Parser, self).__init__(
             whitespace=whitespace,
             nameguard=nameguard,
             comments_re=comments_re,
@@ -528,6 +528,8 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Parser(Parser):
                 self._function_operator_()
             with self._option():
                 self._builtin_operators_()
+            with self._option():
+                self._pseudoinverse_operator_()
             self._error('no available options')
 
     @tatsumasu('Add')
@@ -1401,6 +1403,17 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Parser(Parser):
             []
         )
 
+    @tatsumasu('PseudoInverse')
+    @nomemo
+    def _pseudoinverse_operator_(self):  # noqa
+        self._factor_()
+        self.name_last_node('f')
+        self._pattern('⁺')
+        self.ast._define(
+            ['f'],
+            []
+        )
+
     @tatsumasu('Squareroot')
     def _sqrt_operator_(self):  # noqa
         self._pattern('√')
@@ -2129,6 +2142,8 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Parser(Parser):
                 self._function_operator_()
             with self._option():
                 self._builtin_operators_()
+            with self._option():
+                self._pseudoinverse_in_matrix_operator_()
             self._error('no available options')
 
     @tatsumasu('Power')
@@ -2226,6 +2241,17 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Parser(Parser):
         self._factor_in_matrix_()
         self.name_last_node('f')
         self._pattern('ᵀ')
+        self.ast._define(
+            ['f'],
+            []
+        )
+
+    @tatsumasu('PseudoInverse')
+    @nomemo
+    def _pseudoinverse_in_matrix_operator_(self):  # noqa
+        self._factor_in_matrix_()
+        self.name_last_node('f')
+        self._pattern('⁺')
         self.ast._define(
             ['f'],
             []
@@ -5135,7 +5161,7 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Parser(Parser):
 
     @tatsumasu()
     def _func_id_(self):  # noqa
-        self._identifier_alone_()
+        self._token('!!!')
 
     @tatsumasu('IdentifierAlone')
     def _identifier_alone_(self):  # noqa
@@ -5144,7 +5170,7 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Parser(Parser):
         with self._group():
             with self._choice():
                 with self._option():
-                    self._pattern('[A-Za-z\\p{Ll}\\p{Lu}\\p{Lo}]\\p{M}*([A-Z0-9a-z\\p{Ll}\\p{Lu}\\p{Lo}]\\p{M}*)*')
+                    self._pattern('[A-Za-z\\p{Ll}\\p{Lu}\\p{Lo}]\\p{M}*')
                     self.name_last_node('value')
                 with self._option():
                     self._token('`')
@@ -5158,7 +5184,7 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Parser(Parser):
         )
 
 
-class grammare37f0136aa3ffaf149b351f6a4c948e9Semantics(object):
+class grammarc21f969b5f03d33d43e04f8f136e7682Semantics(object):
     def start(self, ast):  # noqa
         return ast
 
@@ -5411,6 +5437,9 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Semantics(object):
     def trans_operator(self, ast):  # noqa
         return ast
 
+    def pseudoinverse_operator(self, ast):  # noqa
+        return ast
+
     def sqrt_operator(self, ast):  # noqa
         return ast
 
@@ -5499,6 +5528,9 @@ class grammare37f0136aa3ffaf149b351f6a4c948e9Semantics(object):
         return ast
 
     def trans_in_matrix_operator(self, ast):  # noqa
+        return ast
+
+    def pseudoinverse_in_matrix_operator(self, ast):  # noqa
         return ast
 
     def sqrt_in_matrix_operator(self, ast):  # noqa
@@ -5819,7 +5851,7 @@ def main(filename, start=None, **kwargs):
     else:
         with open(filename) as f:
             text = f.read()
-    parser = grammare37f0136aa3ffaf149b351f6a4c948e9Parser()
+    parser = grammarc21f969b5f03d33d43e04f8f136e7682Parser()
     return parser.parse(text, rule_name=start, filename=filename, **kwargs)
 
 
@@ -5827,7 +5859,7 @@ if __name__ == '__main__':
     import json
     from tatsu.util import asjson
 
-    ast = generic_main(main, grammare37f0136aa3ffaf149b351f6a4c948e9Parser, name='grammare37f0136aa3ffaf149b351f6a4c948e9')
+    ast = generic_main(main, grammarc21f969b5f03d33d43e04f8f136e7682Parser, name='grammarc21f969b5f03d33d43e04f8f136e7682')
     print('AST:')
     print(ast)
     print()
@@ -5856,13 +5888,13 @@ class ModelBase(Node):
     pass
 
 
-class grammare37f0136aa3ffaf149b351f6a4c948e9ModelBuilderSemantics(ModelBuilderSemantics):
+class grammarc21f969b5f03d33d43e04f8f136e7682ModelBuilderSemantics(ModelBuilderSemantics):
     def __init__(self, context=None, types=None):
         types = [
             t for t in globals().values()
             if type(t) is type and issubclass(t, ModelBase)
         ] + (types or [])
-        super(grammare37f0136aa3ffaf149b351f6a4c948e9ModelBuilderSemantics, self).__init__(context=context, types=types)
+        super(grammarc21f969b5f03d33d43e04f8f136e7682ModelBuilderSemantics, self).__init__(context=context, types=types)
 
 
 class Start(ModelBase):
@@ -6010,6 +6042,10 @@ class KroneckerProduct(ModelBase):
 
 
 class Transpose(ModelBase):
+    f = None
+
+
+class PseudoInverse(ModelBase):
     f = None
 
 

--- a/iheartla/la_local_parsers/parser_e37f0136aa3ffaf149b351f6a4c948e9_2022-08-17-15-06-38.py
+++ b/iheartla/la_local_parsers/parser_e37f0136aa3ffaf149b351f6a4c948e9_2022-08-17-15-06-38.py
@@ -25,7 +25,7 @@ from tatsu.util import re, generic_main  # noqa
 KEYWORDS = {}  # type: ignore
 
 
-class grammarc21f969b5f03d33d43e04f8f136e7682Buffer(Buffer):
+class grammare37f0136aa3ffaf149b351f6a4c948e9Buffer(Buffer):
     def __init__(
         self,
         text,
@@ -37,7 +37,7 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Buffer(Buffer):
         namechars='',
         **kwargs
     ):
-        super(grammarc21f969b5f03d33d43e04f8f136e7682Buffer, self).__init__(
+        super(grammare37f0136aa3ffaf149b351f6a4c948e9Buffer, self).__init__(
             text,
             whitespace=whitespace,
             nameguard=nameguard,
@@ -49,7 +49,7 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Buffer(Buffer):
         )
 
 
-class grammarc21f969b5f03d33d43e04f8f136e7682Parser(Parser):
+class grammare37f0136aa3ffaf149b351f6a4c948e9Parser(Parser):
     def __init__(
         self,
         whitespace=re.compile('(?!.*)'),
@@ -61,12 +61,12 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Parser(Parser):
         parseinfo=True,
         keywords=None,
         namechars='',
-        buffer_class=grammarc21f969b5f03d33d43e04f8f136e7682Buffer,
+        buffer_class=grammare37f0136aa3ffaf149b351f6a4c948e9Buffer,
         **kwargs
     ):
         if keywords is None:
             keywords = KEYWORDS
-        super(grammarc21f969b5f03d33d43e04f8f136e7682Parser, self).__init__(
+        super(grammare37f0136aa3ffaf149b351f6a4c948e9Parser, self).__init__(
             whitespace=whitespace,
             nameguard=nameguard,
             comments_re=comments_re,
@@ -528,6 +528,8 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Parser(Parser):
                 self._function_operator_()
             with self._option():
                 self._builtin_operators_()
+            with self._option():
+                self._pseudoinverse_operator_()
             self._error('no available options')
 
     @tatsumasu('Add')
@@ -1401,6 +1403,17 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Parser(Parser):
             []
         )
 
+    @tatsumasu('PseudoInverse')
+    @nomemo
+    def _pseudoinverse_operator_(self):  # noqa
+        self._factor_()
+        self.name_last_node('f')
+        self._pattern('⁺')
+        self.ast._define(
+            ['f'],
+            []
+        )
+
     @tatsumasu('Squareroot')
     def _sqrt_operator_(self):  # noqa
         self._pattern('√')
@@ -2129,6 +2142,8 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Parser(Parser):
                 self._function_operator_()
             with self._option():
                 self._builtin_operators_()
+            with self._option():
+                self._pseudoinverse_in_matrix_operator_()
             self._error('no available options')
 
     @tatsumasu('Power')
@@ -2226,6 +2241,17 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Parser(Parser):
         self._factor_in_matrix_()
         self.name_last_node('f')
         self._pattern('ᵀ')
+        self.ast._define(
+            ['f'],
+            []
+        )
+
+    @tatsumasu('PseudoInverse')
+    @nomemo
+    def _pseudoinverse_in_matrix_operator_(self):  # noqa
+        self._factor_in_matrix_()
+        self.name_last_node('f')
+        self._pattern('⁺')
         self.ast._define(
             ['f'],
             []
@@ -5135,7 +5161,7 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Parser(Parser):
 
     @tatsumasu()
     def _func_id_(self):  # noqa
-        self._token('!!!')
+        self._identifier_alone_()
 
     @tatsumasu('IdentifierAlone')
     def _identifier_alone_(self):  # noqa
@@ -5144,7 +5170,7 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Parser(Parser):
         with self._group():
             with self._choice():
                 with self._option():
-                    self._pattern('[A-Za-z\\p{Ll}\\p{Lu}\\p{Lo}]\\p{M}*')
+                    self._pattern('[A-Za-z\\p{Ll}\\p{Lu}\\p{Lo}]\\p{M}*([A-Z0-9a-z\\p{Ll}\\p{Lu}\\p{Lo}]\\p{M}*)*')
                     self.name_last_node('value')
                 with self._option():
                     self._token('`')
@@ -5158,7 +5184,7 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Parser(Parser):
         )
 
 
-class grammarc21f969b5f03d33d43e04f8f136e7682Semantics(object):
+class grammare37f0136aa3ffaf149b351f6a4c948e9Semantics(object):
     def start(self, ast):  # noqa
         return ast
 
@@ -5411,6 +5437,9 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Semantics(object):
     def trans_operator(self, ast):  # noqa
         return ast
 
+    def pseudoinverse_operator(self, ast):  # noqa
+        return ast
+
     def sqrt_operator(self, ast):  # noqa
         return ast
 
@@ -5499,6 +5528,9 @@ class grammarc21f969b5f03d33d43e04f8f136e7682Semantics(object):
         return ast
 
     def trans_in_matrix_operator(self, ast):  # noqa
+        return ast
+
+    def pseudoinverse_in_matrix_operator(self, ast):  # noqa
         return ast
 
     def sqrt_in_matrix_operator(self, ast):  # noqa
@@ -5819,7 +5851,7 @@ def main(filename, start=None, **kwargs):
     else:
         with open(filename) as f:
             text = f.read()
-    parser = grammarc21f969b5f03d33d43e04f8f136e7682Parser()
+    parser = grammare37f0136aa3ffaf149b351f6a4c948e9Parser()
     return parser.parse(text, rule_name=start, filename=filename, **kwargs)
 
 
@@ -5827,7 +5859,7 @@ if __name__ == '__main__':
     import json
     from tatsu.util import asjson
 
-    ast = generic_main(main, grammarc21f969b5f03d33d43e04f8f136e7682Parser, name='grammarc21f969b5f03d33d43e04f8f136e7682')
+    ast = generic_main(main, grammare37f0136aa3ffaf149b351f6a4c948e9Parser, name='grammare37f0136aa3ffaf149b351f6a4c948e9')
     print('AST:')
     print(ast)
     print()
@@ -5856,13 +5888,13 @@ class ModelBase(Node):
     pass
 
 
-class grammarc21f969b5f03d33d43e04f8f136e7682ModelBuilderSemantics(ModelBuilderSemantics):
+class grammare37f0136aa3ffaf149b351f6a4c948e9ModelBuilderSemantics(ModelBuilderSemantics):
     def __init__(self, context=None, types=None):
         types = [
             t for t in globals().values()
             if type(t) is type and issubclass(t, ModelBase)
         ] + (types or [])
-        super(grammarc21f969b5f03d33d43e04f8f136e7682ModelBuilderSemantics, self).__init__(context=context, types=types)
+        super(grammare37f0136aa3ffaf149b351f6a4c948e9ModelBuilderSemantics, self).__init__(context=context, types=types)
 
 
 class Start(ModelBase):
@@ -6010,6 +6042,10 @@ class KroneckerProduct(ModelBase):
 
 
 class Transpose(ModelBase):
+    f = None
+
+
+class PseudoInverse(ModelBase):
     f = None
 
 

--- a/iheartla/la_parser/codegen_eigen.py
+++ b/iheartla/la_parser/codegen_eigen.py
@@ -8,7 +8,7 @@ class CodeGenEigen(CodeGen):
 
     def init_type(self, type_walker, func_name):
         super().init_type(type_walker, func_name)
-        self.pre_str = '''#include <Eigen/Core>\n#include <Eigen/Dense>\n#include <Eigen/Sparse>\n#include <iostream>\n#include <set>\n'''
+        self.pre_str = '''#include <Eigen/Core>\n#include <Eigen/QR>\n#include <Eigen/Dense>\n#include <Eigen/Sparse>\n#include <iostream>\n#include <set>\n'''
         self.post_str = ''''''
         self.ret = 'ret'
         if self.unofficial_method:
@@ -859,6 +859,11 @@ class CodeGenEigen(CodeGen):
         f_info.content = "{}.transpose()".format(f_info.content)
         return f_info
 
+    def visit_pseudoinverse(self, node, **kwargs):
+        f_info = self.visit(node.f, **kwargs)
+        f_info.content = "{}.completeOrthogonalDecomposition().pseudoInverse()".format(f_info.content)
+        return f_info
+        
     def visit_squareroot(self, node, **kwargs):
         f_info = self.visit(node.value, **kwargs)
         f_info.content = "sqrt({})".format(f_info.content)

--- a/iheartla/la_parser/codegen_latex.py
+++ b/iheartla/la_parser/codegen_latex.py
@@ -669,6 +669,9 @@ class CodeGenLatex(CodeGen):
     def visit_transpose(self, node, **kwargs):
         return "{{{}}}^T".format(self.visit(node.f, **kwargs))
 
+    def visit_pseudoinverse(self, node, **kwargs):
+        return "{{{}}}^+".format(self.visit(node.f, **kwargs))
+
     def visit_squareroot(self, node, **kwargs):
         if node.value.node_type == IRNodeType.Factor and node.value.sub:  # sub expression
             content = self.visit(node.value.sub.value, **kwargs)

--- a/iheartla/la_parser/codegen_matlab.py
+++ b/iheartla/la_parser/codegen_matlab.py
@@ -801,6 +801,11 @@ class CodeGenMatlab(CodeGen):
         f_info.content = "{}'".format(f_info.content)
         return f_info
 
+    def visit_pseudoinverse(self, node, **kwargs):
+        f_info = self.visit(node.f, **kwargs)
+        f_info.content = "pinv({})".format(f_info.content)
+        return f_info
+
     def visit_squareroot(self, node, **kwargs):
         f_info = self.visit(node.value, **kwargs)
         f_info.content = "sqrt({})".format(f_info.content)

--- a/iheartla/la_parser/codegen_numpy.py
+++ b/iheartla/la_parser/codegen_numpy.py
@@ -773,6 +773,14 @@ class CodeGenNumpy(CodeGen):
             f_info.content = "{}.T".format(f_info.content)
         return f_info
 
+    def visit_pseudoinverse(self, node, **kwargs):
+        f_info = self.visit(node.f, **kwargs)
+        if node.f.la_type.is_vector():
+            f_info.content = "{}.T.reshape(1, {}) / ({}.dot({})) ".format(f_info.content, node.f.la_type.rows)
+        else:
+            f_info.content = "np.linalg.pinv({})".format(f_info.content)
+        return f_info
+
     def visit_squareroot(self, node, **kwargs):
         f_info = self.visit(node.value, **kwargs)
         f_info.content = "np.sqrt({})".format(f_info.content)

--- a/iheartla/la_parser/ir.py
+++ b/iheartla/la_parser/ir.py
@@ -55,6 +55,7 @@ class IRNodeType(Enum):
     KroneckerProduct = 219
     DotProduct = 220
     Squareroot = 221
+    PseudoInverse = 222
     # matrix
     Matrix = 300
     MatrixRows = 301
@@ -734,6 +735,10 @@ class TransposeNode(ExprNode):
         super().__init__(IRNodeType.Transpose, parse_info=parse_info, raw_text=raw_text)
         self.f = None
 
+class PseudoInverseNode(ExprNode):
+    def __init__(self, parse_info=None, raw_text=None):
+        super().__init__(IRNodeType.PseudoInverse, parse_info=parse_info, raw_text=raw_text)
+        self.f = None
 
 class SquarerootNode(ExprNode):
     def __init__(self, parse_info=None, raw_text=None):

--- a/iheartla/la_parser/ir_visitor.py
+++ b/iheartla/la_parser/ir_visitor.py
@@ -327,6 +327,7 @@ class IRVisitor(object):
             IRNodeType.Summation: "visit_summation",
             IRNodeType.Norm: "visit_norm",
             IRNodeType.Transpose: "visit_transpose",
+            IRNodeType.PseudoInverse: "visit_pseudoinverse",
             IRNodeType.Squareroot: "visit_squareroot",
             IRNodeType.Power: "visit_power",
             IRNodeType.Solver: "visit_solver",
@@ -465,6 +466,9 @@ class IRVisitor(object):
         pass
 
     def visit_transpose(self, node, **kwargs):
+        pass
+
+    def visit_pseudoinverse(self, node, **kwargs):
         pass
 
     def visit_squareroot(self, node, **kwargs):

--- a/iheartla/la_parser/type_walker.py
+++ b/iheartla/la_parser/type_walker.py
@@ -1960,6 +1960,24 @@ class TypeWalker(NodeWalker):
         node_info.la_type = node_type
         return node_info
 
+    def walk_PseudoInverse(self, node, **kwargs):
+        ir_node = PseudoInverseNode(parse_info=node.parseinfo)
+        f_info = self.walk(node.f, **kwargs)
+        ir_node.f = f_info.ir
+        assert f_info.la_type.is_matrix() or f_info.la_type.is_vector(), get_err_msg_info(f_info.ir.parse_info,"Pseudoinverse error. The base must be a matrix or vector")
+        if f_info.la_type.is_matrix():
+            node_type = MatrixType(rows=f_info.la_type.cols, cols=f_info.la_type.rows, sparse=f_info.la_type.sparse)
+            if f_info.la_type.is_dynamic_row():
+                node_type.set_dynamic_type(DynamicTypeEnum.DYN_COL)
+            if f_info.la_type.is_dynamic_col():
+                node_type.set_dynamic_type(DynamicTypeEnum.DYN_ROW)
+        elif f_info.la_type.is_vector():
+            node_type = MatrixType(rows=1, cols=f_info.la_type.rows)
+        node_info = NodeInfo(node_type, symbols=f_info.symbols)
+        node_info.ir = ir_node
+        node_info.la_type = node_type
+        return node_info
+
     def walk_Squareroot(self, node, **kwargs):
         ir_node = SquarerootNode(parse_info=node.parseinfo)
         f_info = self.walk(node.f, **kwargs)

--- a/iheartla/la_tools/la_helper.py
+++ b/iheartla/la_tools/la_helper.py
@@ -11,7 +11,7 @@ from .la_logger import *
 
 
 DEBUG_MODE = True
-DEBUG_PARSER = False  # used for new grammer files
+DEBUG_PARSER = True  # used for new grammer files
 DEBUG_TIME = False    # used for time recoding (to optimize)
 TEST_MATLAB = False   # used for running tests for MATLAB
 start_time = None

--- a/iheartla/la_tools/la_msg.py
+++ b/iheartla/la_tools/la_msg.py
@@ -64,6 +64,7 @@ class LaMsg(object):
                 "cross_product_in_matrix_operator": "cross product",
                 "kronecker_product_in_matrix_operator": "kronecker product",
                 "trans_in_matrix_operator": "transpose",
+                "pseudoinverse_in_matrix_operator": "pseudoinverse",
                 "sqrt_in_matrix_operator": "squareroot",
                 "sum_in_matrix_operator": "sum",
                 "power_in_matrix_operator": "power",


### PR DESCRIPTION
Added support for the Moore-Penrose Inverse ("pseudoinverse") as implemented in Eigen, NumPy, MATLAB, etc.

The pseudoinverse can be invoked using the ' ⁺ ' (U+207A) character.

Example: The code
```
B = A⁺
where
A: ℝ ^ (4 × 4): a matrix
```
returns `B`, the pseudoinverse of A.
